### PR TITLE
test_discoverable_devices: google,tomato: Fix usb device matching

### DIFF
--- a/kselftest/test_discoverable_devices/boards/google,tomato.yaml
+++ b/kselftest/test_discoverable_devices/boards/google,tomato.yaml
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (c) 2024 Collabora Ltd
 - type: usb-controller
-  dt-mmio: 112a0000
+  of-fullname-regex: .*112a1000.*
   usb-version: 2
   devices:
     - path: 1
       interfaces: [0, 1]
       name: camera
 - type: usb-controller
-  dt-mmio: 112b0000
+  of-fullname-regex: .*112b1000.*
   usb-version: 2
   devices:
     - path: 1


### PR DESCRIPTION
The device tree nodes that register the USB controllers on MT8195 have address set to 0 relative to the parent node. As a result, the current dt-mmio properties fail to match the controllers, and it's not even possible to use them to uniquely match the devices. Use the of-fullname-regex property instead to be able to match based on the parent's address and update the address accordingly.

Depends on the series enabling the new property to be merged upstream: https://lore.kernel.org/all/20240613-kselftest-discoverable-probe-mt8195-kci-v1-0-7b396a9b032d@collabora.com